### PR TITLE
Medis imp export api fe valid

### DIFF
--- a/app/frontend/src/components/designer/FormViewerMultiUpload.vue
+++ b/app/frontend/src/components/designer/FormViewerMultiUpload.vue
@@ -435,12 +435,12 @@ export default {
     },
     convertEmptyArraysToNull(obj) {
       /*
-      * This function is purely made to solve this https://github.com/formio/formio.js/issues/4515 formio bug 
-      * where setSubmission mislead payload for submission. In our case if setSubmission got triggered multiple
-      * time it cache submission key's with old values that leads to trigger false validation errors.
-      * This function clear object with some empty arrays to null. Main problem was occured to columns and grids components.
-      */
-      
+       * This function is purely made to solve this https://github.com/formio/formio.js/issues/4515 formio bug
+       * where setSubmission mislead payload for submission. In our case if setSubmission got triggered multiple
+       * time it cache submission key's with old values that leads to trigger false validation errors.
+       * This function clear object with some empty arrays to null. Main problem was occured to columns and grids components.
+       */
+
       if (_.isArray(obj)) {
         return obj.length === 0 ? null : obj.map(this.convertEmptyArraysToNull);
       } else if (_.isObject(obj)) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Convert empty arrays to null when doing multi upload
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There is a bug in form.io framework to do with arrays when calling validation defined for the form. The bug exposes itself when you call validation routine more than once (our case in multi upload). The work around for this bug is to replace empty arrays in json payload will null.
## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [X] I have run the npm script lint on the frontend and backend
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
